### PR TITLE
Correct and improve physrisk-api dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,29 @@
-FROM python:3.8-alpine
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-RUN mkdir -p /usr/src/app
-COPY . /usr/src/app
-WORKDIR /usr/src/app
+# Create working directory
+RUN mkdir -p /usr/local/src/app
+# Add source(s)
+COPY . /usr/local/src/app
+# Enter working directory
+WORKDIR /usr/local/src/app
 
-RUN pip install .
+# Install
+RUN \
+    # Install shadow-utils for adduser functionality
+    microdnf -y install shadow-utils \
+    # Install Python 3.8
+    && microdnf -y install python38 \
+    # Install application
+    && pip3 install . \
+    # Clean up unnecessary data
+    && microdnf clean all && rm -rf /var/cache/yum
 
+# Run as non-root user
+RUN adduser physrisk-api
+USER physrisk-api
+
+# Enable communication via port 8081
 EXPOSE 8081
 
+# Run application
 CMD ["waitress-serve", "--port=8081", "--call", "src.physrisk_api.app:create_app"]


### PR DESCRIPTION
With the inclusion of the physrisk library, numpy was introduced which
doesn't play well on the python3.8 alpine container image.

This commit switches to Red Hat's UBI8 minimal image for container
builds, making additional necessary changes to the dockerfile for it.

Signed-off-by: Nathan Gillett <ngillett@redhat.com>